### PR TITLE
travis-ci: migrate from tarpaulin to kcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,13 @@ addons:
 
 cache: cargo
 rust:
+  - stable
+  - beta
   - nightly
 
 script:
-- cargo test
+  - cargo build
+  - cargo test
 
 after_success: |
     wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,32 @@ addons:
     apt:
         packages:
             - libssl-dev
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - gcc
+            - binutils-dev
+            - libiberty-dev
+
 cache: cargo
 rust:
   - nightly
-
-install: |
-  cargo install cargo-tarpaulin || :
 
 script:
 - cargo test
 
 after_success: |
-  cargo tarpaulin --all --exclude-files tests/* macros/* --out Xml
-  bash <(curl -s https://codecov.io/bash)
+    wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+    tar xzf master.tar.gz &&
+    cd kcov-master &&
+    mkdir build &&
+    cd build &&
+    cmake .. &&
+    make &&
+    make install DESTDIR=../../kcov-build &&
+    cd ../.. &&
+    rm -rf kcov-master &&
+    for file in target/debug/drop-*; do [ -x "${file}" ] || continue; mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+    bash <(curl -s https://codecov.io/bash) &&
+    echo "Uploaded code coverage"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(const_fn)]
-#![feature(specialization)]
-
 /// Secure communication channels using sodiumoxide
 pub mod crypto;
 /// Error definition and handling


### PR DESCRIPTION
Migrate code coverage to use kcov instead of tarpaulin.
Remove unused nightly feature and CI for every version of Rust