### PR TITLE
RFC refactoring SystemManager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = { version = "0.1", optional = true }
 tracing-futures = { version = "0.2", optional = true }
 tracing-subscriber = { version = "0.1", optional = true }
 peroxide = { version = "0.27", optional = true }
-postage = "0.4"
+postage = { version = "0.4", features = [ "logging" ] }
 
 # pending inclusion of stream in std
 tokio-stream = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing = { version = "0.1", optional = true }
 tracing-futures = { version = "0.2", optional = true }
 tracing-subscriber = { version = "0.1", optional = true }
 peroxide = { version = "0.27", optional = true }
-postage = { version = "0.4", features = [ "logging" ] }
+postage = { version = "0.4", features = [ "logging", "futures-traits" ] }
 
 # pending inclusion of stream in std
 tokio-stream = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tracing = { version = "0.1", optional = true }
 tracing-futures = { version = "0.2", optional = true }
 tracing-subscriber = { version = "0.1", optional = true }
 peroxide = { version = "0.27", optional = true }
+postage = "0.4"
 
 # pending inclusion of stream in std
 tokio-stream = "0.1"

--- a/src/system/manager.rs
+++ b/src/system/manager.rs
@@ -148,7 +148,7 @@ impl<M: Message + 'static> SystemManager<M> {
         let mut incoming = self.incoming;
 
         let (msg_tx, msg_rx) = dispatch::channel(128);
-        let (error_tx, error_rx) = dispatch::channel(32);
+        let (error_tx, _) = dispatch::channel(32);
         let (mut connection_tx, connection_rx) = mpsc::channel(16);
 
         let perr_tx = error_tx.clone();

--- a/src/test/system.rs
+++ b/src/test/system.rs
@@ -170,7 +170,6 @@ where
             .map(|(idx, (key, msg))| {
                 let p = processor.clone();
                 let sender = sender.clone();
-                let msg = Arc::new(msg);
 
                 async move {
                     trace!(


### PR DESCRIPTION
This adds a few new features to SystemManager:

- Limit the maximum number of task that process messages in parrallel
- Messages are now read by actual agents
- SystemManager now actually uses disconnect notifications
- SystemManager::run now returns a SystemHandle instead of the Processor::Handle directly
- Users can get a Stream of errors from the SystemHandle
- Users can add new Connection to a running system using the SystemHandle

Design is WIP