### PR TITLE
Keypair {de,}serialize

### DIFF
--- a/src/crypto/key/exchange.rs
+++ b/src/crypto/key/exchange.rs
@@ -76,7 +76,7 @@ impl From<SodiumSecKey> for SecretKey {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 /// A `KeyPair` that can be used to exchange a secret symmetric key for use in an encrypted network stream
 pub struct KeyPair {
     public: PublicKey,

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -104,7 +104,7 @@ impl AsRef<[u8]> for SecretKey {
 }
 
 /// A key pair that can be used for both signing and verifying messages
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct KeyPair {
     public: PublicKey,
     secret: SecretKey,


### PR DESCRIPTION
In order to load & save KeyPairs from files.