### PR TITLE
Allow sampling with an exclusion list

### DIFF
--- a/src/system/sampler.rs
+++ b/src/system/sampler.rs
@@ -44,6 +44,22 @@ pub trait Sampler: Send + Sync {
         self.sample_unchecked(keys, expected, actual).await
     }
 
+    /// Sample from a set with a given list of exclusions
+    async fn sample_excluding<I>(
+        &self,
+        keys: I,
+        excluding: &[PublicKey],
+        expected: usize,
+    ) -> Result<HashSet<PublicKey>, SampleError>
+    where
+        I: IntoIterator<Item = PublicKey> + Send,
+        I::IntoIter: Send,
+    {
+        let sample = keys.into_iter().filter(|x| !excluding.contains(&x));
+
+        self.sample(sample, expected).await
+    }
+
     /// Takes a sample from an `Iterator` already knowing its bounds.
     /// This is the only method that should be implemented in custom `Sampler`s
     async fn sample_unchecked<I: Iterator<Item = PublicKey> + Send>(

--- a/src/system/sampler.rs
+++ b/src/system/sampler.rs
@@ -171,6 +171,22 @@ mod test {
     }
 
     #[tokio::test]
+    async fn exclusions() {
+        let mut keys = keyset(10);
+        let exclusions = keys.by_ref().take(5).collect::<Vec<_>>();
+        let keys = keys.collect::<Vec<_>>();
+
+        let sampler = AllSampler::default();
+
+        let sample = sampler
+            .sample_excluding(keys.iter().copied(), &exclusions, keys.len())
+            .await
+            .expect("sampling failed");
+
+        assert_eq!(sample.len(), keys.len());
+    }
+
+    #[tokio::test]
     async fn poisson() {
         sampling_test!(
             PoissonSampler,

--- a/src/system/sampler.rs
+++ b/src/system/sampler.rs
@@ -29,6 +29,9 @@ pub enum SampleError {
 }
 
 /// Trait used when sampling a set of known peers
+/// # FIXME
+/// allocation for the output sample is required pending stabilisation of impl trait in type alias
+/// https://github.com/rust-lang/rust/issues/63063
 #[async_trait]
 pub trait Sampler: Send + Sync {
     /// Take a sample of keys from the provided `Sender`


### PR DESCRIPTION
This adds the provided associated function sample_excluding to the Sampler trait