### PR TITLE
net/connector/tcp: retry establishement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ sodiumoxide = "0.2"
 snafu = "~0.6"
 serde = { version = "~1.0", features = [ "derive", "rc" ] }
 bincode = "~1.3"
+backoff = { version = "0.3", features = ["tokio"] }
 tokio = { version = "1", features = [ "net", "sync", "rt", "io-util", "time" ], optional = true }
 tokio-utp = { version = "0.8.0-alpha1", branch = "async", git = "https://github.com/Distributed-EPFL/tokio-utp", optional = true }
 futures = { version = "0.3", optional = true }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -6,6 +6,7 @@ pub use common::directory::Info as DirectoryInfo;
 pub mod connector;
 pub use connector::ConnectError;
 pub use connector::Connector;
+pub use connector::ConnectorExt;
 pub use connector::Directory as DirectoryConnector;
 pub use connector::Resolve as ResolveConnector;
 pub use connector::Tcp as TcpConnector;


### PR DESCRIPTION
When using a TCPConnector, it bails out at the first error, which might be only temporary. This patch retry establishing the connection.

I tried using it direclty in `System::new`, but there was some issues with `F` not being `Copy`.
And why is it taking an `IntoIterator` and not a `Vec`? That's a bit cumbersome to use it (as I have to copy it when retrying the block).