### PR TITLE
crypto/sign.KeyPair: add From<PrivateKey>

### DIFF
--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -212,6 +212,15 @@ impl PartialEq for KeyPair {
 
 impl Eq for KeyPair {}
 
+impl From<PrivateKey> for KeyPair {
+    fn from(private: PrivateKey) -> Self {
+        Self(Keypair {
+            public: DalekPublicKey::from(&private.0),
+            secret: private.0,
+        })
+    }
+}
+
 /// A signature that can be used to verify the authenticity of a message
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Signature(DalekSignature);


### PR DESCRIPTION
As to avoid having to keep both the public & the private key on construction.