### PR TITLE
bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "~1.0", features = [ "derive", "rc" ] }
 snafu = "~0.6"
 tokio = { version = "1", features = [ "net", "sync", "rt", "io-util", "time" ], optional = true }
 tracing-futures = { version = "0.2", optional = true }
-tracing-subscriber = { version = "0.2", optional = true }
+tracing-subscriber = { version = "0.3", optional = true }
 tracing = { version = "0.1", optional = true }
 
 # pending inclusion of stream in std
@@ -50,7 +50,7 @@ drop = { path = ".", features = [ "system" ] }
 tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
 tracing = "0.1"
 tracing-futures = "0.2"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 
 [features]
 default = []


### PR DESCRIPTION
`tracing-subscriber` was bumped to remove the deps on `time` thus avoiding its vulnerability.